### PR TITLE
feat: .NET 8.0, dedicated images from DockerHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,4 @@ MigrationBackup/
 /Bridge-To-Kubernetes
 /bridge-to-kubernetes
 /.idea
+/src/.idea

--- a/src/EndpointManagerLauncher/endpointmanagerlauncher.csproj
+++ b/src/EndpointManagerLauncher/endpointmanagerlauncher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <DebugType>portable</DebugType>

--- a/src/LocalAgent/Dockerfile_
+++ b/src/LocalAgent/Dockerfile_
@@ -30,7 +30,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -o /src/publish
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine3.17 as final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.18 as final
 
 # Setup common tools
 COPY /build/setup-alpine-tools.sh .

--- a/src/LocalAgent/LocalAgent.csproj
+++ b/src/LocalAgent/LocalAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <AssemblyName>Microsoft.BridgeToKubernetes.LocalAgent</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.LocalAgent</RootNamespace>

--- a/src/common.tests/common.tests.csproj
+++ b/src/common.tests/common.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.BridgeToKubernetes.Common.Tests</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.Common.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/common/Constants.cs
+++ b/src/common/Constants.cs
@@ -218,7 +218,7 @@ namespace Microsoft.BridgeToKubernetes.Common
 
         internal static class ImageName
         {
-            public const string RemoteAgentImageName = "lpkremoteagent";
+            public const string RemoteAgentImageName = "petrbuchinfin/lpkremoteagent";
         }
 
         internal static class Https

--- a/src/common/common.csproj
+++ b/src/common/common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.BridgeToKubernetes.Common</AssemblyName>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/devhostAgent.restorationjob.tests/devhostAgent.restorationjob.tests.csproj
+++ b/src/devhostAgent.restorationjob.tests/devhostAgent.restorationjob.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>restorationjob.tests</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.DevHostAgent.RestorationJob.Tests</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/src/devhostagent.restorationjob/Dockerfile
+++ b/src/devhostagent.restorationjob/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0-cbl-mariner2.0@sha256:9e054d0663d07e09127d114f753c1068d0bf681eab188352d06f111ce68f050f AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
 ARG TARGETARCH
 ARG Configuration=Release
 ARG TelemetryType=TELEMETRY_DEVELOPMENT
@@ -18,7 +18,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -a ${TARGETARCH} --self-contained false --no-restore -o /output devhostAgent.restorationjob.csproj
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-cbl-mariner2.0@sha256:ea1751dfd2defec87508aa979088741935d1fd4c870bfd53e7645642fc9ead13 as final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS final
 
 # Setup common tools
 RUN tdnf clean all && \
@@ -32,4 +32,3 @@ RUN tdnf install -y \
 WORKDIR /app
 COPY --from=build /output /app
 ENTRYPOINT ["/app/restorationjob"]
-

--- a/src/devhostagent.restorationjob/devhostAgent.restorationjob.csproj
+++ b/src/devhostagent.restorationjob/devhostAgent.restorationjob.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>restorationjob</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <TieredCompilation>true</TieredCompilation>
     <RuntimeIdentifiers>linux-x64;linux-arm64;linux-musl-arm64;linux-musl-x64;win-x64;win-arm64</RuntimeIdentifiers>

--- a/src/devhostagent/Dockerfile
+++ b/src/devhostagent/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0-cbl-mariner2.0@sha256:9e054d0663d07e09127d114f753c1068d0bf681eab188352d06f111ce68f050f AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
 
 ARG TARGETARCH
 ARG Configuration=Release
@@ -19,7 +19,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -a ${TARGETARCH} --self-contained false --no-restore -o /src/publish devhostAgent.csproj
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-cbl-mariner2.0@sha256:ea1751dfd2defec87508aa979088741935d1fd4c870bfd53e7645642fc9ead13 as final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 as final
 
 RUN tdnf clean all && \
  tdnf check-update && \

--- a/src/devhostagent/devhostAgent.csproj
+++ b/src/devhostagent/devhostAgent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>devhostAgent</AssemblyTitle>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <TieredCompilation>true</TieredCompilation>
     <RuntimeIdentifiers>linux-x64;linux-arm64;linux-musl-arm64;linux-musl-x64;win-x64;win-arm64</RuntimeIdentifiers>

--- a/src/dsc.tests/dsc.tests.csproj
+++ b/src/dsc.tests/dsc.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>dsc.tests</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.Exe.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/dsc/dsc.csproj
+++ b/src/dsc/dsc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <DebugType>portable</DebugType>

--- a/src/endpointmanager.tests/endpointmanager.tests.csproj
+++ b/src/endpointmanager.tests/endpointmanager.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>EndpointManager.tests</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.EndpointManager.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/endpointmanager/endpointmanager.csproj
+++ b/src/endpointmanager/endpointmanager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <DebugType>portable</DebugType>

--- a/src/library.tests/library.tests.csproj
+++ b/src/library.tests/library.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.BridgeToKubernetes.Library.Tests</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.Library.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/library/ImageProvider.cs
+++ b/src/library/ImageProvider.cs
@@ -22,11 +22,11 @@ namespace Microsoft.BridgeToKubernetes.Library
 
         private static readonly IReadOnlyDictionary<ReleaseEnvironment, string> ContainerRegistries = new Dictionary<ReleaseEnvironment, string>()
             {
-                { ReleaseEnvironment.Production, "bridgetok8s.azurecr.io" },
-                { ReleaseEnvironment.Staging, "mindarostage.azurecr.io" },
-                { ReleaseEnvironment.Development, "mindarodev.azurecr.io" },
-                { ReleaseEnvironment.Local, "mindarodev.azurecr.io" },
-                { ReleaseEnvironment.Test, "mindarodev.azurecr.io" }
+                { ReleaseEnvironment.Production, "docker.io" },
+                { ReleaseEnvironment.Staging, "docker.io" },
+                { ReleaseEnvironment.Development, "docker.io" },
+                { ReleaseEnvironment.Local, "docker.io" },
+                { ReleaseEnvironment.Test, "docker.io" }
             };
 
         internal static class DevHost
@@ -66,7 +66,7 @@ namespace Microsoft.BridgeToKubernetes.Library
 
             public static string Version => _tag.Value;
 
-            internal static string Name => $"lpkrestorationjob:{_tag.Value}";
+            internal static string Name => $"petrbuchinfin/lpkrestorationjob:{_tag.Value}";
         }
 
         private static class RoutingManager

--- a/src/library/library.csproj
+++ b/src/library/library.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AssemblyName>Microsoft.BridgeToKubernetes.Library</AssemblyName>

--- a/src/routingmanager.tests/routingmanager.tests.csproj
+++ b/src/routingmanager.tests/routingmanager.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <AssemblyName>Microsoft.BridgeToKubernetes.RoutingManager.Tests</AssemblyName>
       <RootNamespace>Microsoft.BridgeToKubernetes.RoutingManager.Tests</RootNamespace>
       <IsPackable>false</IsPackable>

--- a/src/routingmanager/Dockerfile
+++ b/src/routingmanager/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0-cbl-mariner2.0@sha256:9e054d0663d07e09127d114f753c1068d0bf681eab188352d06f111ce68f050f AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
 ARG TARGETARCH
 ARG Configuration=Release
 ARG TelemetryType=TELEMETRY_DEVELOPMENT
@@ -19,7 +19,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -a ${TARGETARCH} --self-contained false --no-restore -o /src/publish
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-cbl-mariner2.0@sha256:ea1751dfd2defec87508aa979088741935d1fd4c870bfd53e7645642fc9ead13 as final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 as final
 ARG TARGETARCH
 ARG KUBECTL_VERSION=v1.27.3
 ARG INSTALL_LOCATION=/app/kubectl/linux

--- a/src/routingmanager/routingmanager.csproj
+++ b/src/routingmanager/routingmanager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <AssemblyName>Microsoft.BridgeToKubernetes.RoutingManager</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.RoutingManager</RootNamespace>

--- a/src/testhelpers/testhelpers.csproj
+++ b/src/testhelpers/testhelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.BridgeToKubernetes.TestHelpers</AssemblyName>
     <RootNamespace>Microsoft.BridgeToKubernetes.TestHelpers</RootNamespace>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\build\FinalPublicKey.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Project is updated to use .NET v8.0, since .NET 7.0 is deprecated.
Also images will now be built by us and downloaded from DockerHub, since native images require .NET 7.0 and do not work already, and also they will be anavailable as soon as April 2025. 